### PR TITLE
Update to azure-mgmt-web 0.32.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ The sample creates, lists and updates a website.
 It starts by setting up a ResourceManagementClient and a WebSiteManagementClient object using your subscription and credentials.
 
 ```python
+import os
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.mgmt.resource import ResourceManagementClient
+from azure.mgmt.web import WebSiteManagementClient
+
 subscription_id = os.environ['AZURE_SUBSCRIPTION_ID']
 
 credentials = ServicePrincipalCredentials(
@@ -96,7 +101,7 @@ resource_group_params = {'location':'westus'}
 Create a server farm to host your website.
 
 ```python
-from azure.mgmt.web.models import ServerFarmWithRichSku, SkuDescription
+from azure.mgmt.web.models import AppServicePlan, SkuDescription, Site
 
 server_farm_async_operation = web_client.server_farms.create_or_update_server_farm(
     GROUP_NAME,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ This sample demonstrates how to manage your Azure websites using a Python client
     git clone https://github.com:Azure-Samples/app-service-web-python-manage.git
     ```
 
-1. Install the dependencies using pip.
+1. Install the dependencies using pip. This step requires `pip` version >=6.0 and `setuptools` version >=8.0.
+    To check that you have the required versions, use `pip --version` and `easy_install --version`.
 
     ```
     cd app-service-web-python-manage

--- a/README.md
+++ b/README.md
@@ -95,18 +95,18 @@ The sample then sets up a resource group in which it will create the website.
 resource_group_params = {'location':'westus'}
 ```
 
-<a id="create-server-farm"></a>
-### Create a server farm
+<a id="create-service-plan"></a>
+### Create an App Service plan
 
-Create a server farm to host your website.
+Create a service plan to host your webapp.
 
 ```python
 from azure.mgmt.web.models import AppServicePlan, SkuDescription, Site
 
-server_farm_async_operation = web_client.server_farms.create_or_update_server_farm(
+service_plan_async_operation = web_client.app_service_plans.create_or_update(
     GROUP_NAME,
     SERVER_FARM_NAME,
-    ServerFarmWithRichSku(
+    AppServicePlan(
         location=WEST_US,
         sku=SkuDescription(
             name='S1',
@@ -115,8 +115,8 @@ server_farm_async_operation = web_client.server_farms.create_or_update_server_fa
         )
     )
 )
-server_farm = server_farm_async_operation.result()
-print_item(server_farm)
+service_plan = service_plan_async_operation.result()
+print_item(service_plan)
 ```
 
 <a id="create-website"></a>
@@ -130,7 +130,7 @@ site_async_operation = web_client.sites.create_or_update_site(
     SITE_NAME,
     Site(
         location=WEST_US,
-        server_farm_id=server_farm.id
+        server_farm_id=service_plan.id
     )
 )
 site = site_async_operation.result()
@@ -141,7 +141,7 @@ print_item(site)
 ### List websites in the resourcegroup
 
 ```python
-for site in web_client.sites.get_sites(GROUP_NAME).value:
+for site in web_client.web_apps.list_by_resource_group(GROUP_NAME):
     print_item(site)
 ```
 
@@ -149,14 +149,14 @@ for site in web_client.sites.get_sites(GROUP_NAME).value:
 ### Get details for the given website
 
 ```python
-web_client.sites.get_site(GROUP_NAME, SITE_NAME)
+web_client.web_apps.get(GROUP_NAME, SITE_NAME)
 ```
 
 <a id="delete-site"></a>
 ### Delete a website
 
 ```python
-web_client.sites.delete_site(GROUP_NAME, SITE_NAME)
+web_client.web_apps.delete(GROUP_NAME, SITE_NAME)
 ```
 
 At this point, the sample also deletes the resource group that it created.

--- a/README.md
+++ b/README.md
@@ -73,14 +73,8 @@ The sample creates, lists and updates a website.
 It starts by setting up a ResourceManagementClient and a WebSiteManagementClient object using your subscription and credentials.
 
 ```python
-import os
-from azure.common.credentials import ServicePrincipalCredentials
-from azure.mgmt.resource import ResourceManagementClient
-from azure.mgmt.web import WebSiteManagementClient
+subscription_id = os.environ['AZURE_SUBSCRIPTION_ID']
 
-subscription_id = os.environ.get(
-    'AZURE_SUBSCRIPTION_ID',
-    '11111111-1111-1111-1111-111111111111') # your Azure Subscription Id
 credentials = ServicePrincipalCredentials(
     client_id=os.environ['AZURE_CLIENT_ID'],
     secret=os.environ['AZURE_CLIENT_SECRET'],

--- a/example.py
+++ b/example.py
@@ -118,7 +118,7 @@ def print_item(group):
     print("\tId: {}".format(group.id))
     print("\tLocation: {}".format(group.location))
     print("\tTags: {}".format(group.tags))
-    if hasattr(group, 'status'): # ServerFarmWithRichSku
+    if hasattr(group, 'status'):
         print("\tStatus: {}".format(group.status))
     if hasattr(group, 'state'): # Site
         print("\tStatus: {}".format(group.state))

--- a/example.py
+++ b/example.py
@@ -21,6 +21,7 @@ GROUP_NAME = 'azure-sample-group'
 SERVER_FARM_NAME = 'sample-server-farm'
 SITE_NAME = Haikunator().haikunate()
 
+
 def run_example():
     """Web Site management example."""
     #
@@ -110,6 +111,7 @@ def run_example():
     delete_async_operation = resource_client.resource_groups.delete(GROUP_NAME)
     delete_async_operation.wait()
 
+
 def print_item(group):
     """Print an instance."""
     print("\tName: {}".format(group.name))
@@ -124,11 +126,13 @@ def print_item(group):
         print_properties(group.properties)
     print("\n\n")
 
+
 def print_properties(props):
     """Print a Site properties instance."""
     if props and props.provisioning_state:
         print("\tProperties:")
         print("\t\tProvisioning State: {}".format(props.provisioning_state))
+
 
 if __name__ == "__main__":
     run_example()

--- a/example.py
+++ b/example.py
@@ -113,7 +113,7 @@ def run_example():
 
 
 def print_item(group):
-    """Print an instance."""
+    """Print some properties of an Azure model."""
     print("\tName: {}".format(group.name))
     print("\tId: {}".format(group.id))
     print("\tLocation: {}".format(group.location))
@@ -128,7 +128,7 @@ def print_item(group):
 
 
 def print_properties(props):
-    """Print a Site properties instance."""
+    """Print some properties of a Site."""
     if props and props.provisioning_state:
         print("\tProperties:")
         print("\t\tProvisioning State: {}".format(props.provisioning_state))

--- a/example.py
+++ b/example.py
@@ -46,11 +46,11 @@ def run_example():
     print_item(resource_client.resource_groups.create_or_update(GROUP_NAME, resource_group_params))
 
     #
-    # Create a Server Farm for your WebApp
+    # Create an App Service plan for your WebApp
     #
-    print('Create a Server Farm for your WebApp')
+    print('Create an App Service plan for your WebApp')
 
-    server_farm_async_operation = web_client.app_service_plans.create_or_update(
+    service_plan_async_operation = web_client.app_service_plans.create_or_update(
         GROUP_NAME,
         SERVER_FARM_NAME,
         AppServicePlan(
@@ -62,19 +62,19 @@ def run_example():
             )
         )
     )
-    server_farm = server_farm_async_operation.result()
-    print_item(server_farm)
+    service_plan = service_plan_async_operation.result()
+    print_item(service_plan)
 
     #
-    # Create a Site to be hosted in the Server Farm
+    # Create a Site to be hosted on the App Service plan
     #
-    print('Create a Site to be hosted in the Server Farm')
+    print('Create a Site to be hosted on the App Service plan')
     site_async_operation = web_client.web_apps.create_or_update(
         GROUP_NAME,
         SITE_NAME,
         Site(
             location=WEST_US,
-            server_farm_id=server_farm.id
+            server_farm_id=service_plan.id
         )
     )
     site = site_async_operation.result()

--- a/example.py
+++ b/example.py
@@ -1,3 +1,13 @@
+"""Sample code demonstrating management of Azure web apps.
+
+This script expects that the following environment vars are set:
+
+AZURE_TENANT_ID: with your Azure Active Directory tenant id or domain
+AZURE_CLIENT_ID: with your Azure Active Directory Application Client ID
+AZURE_CLIENT_SECRET: with your Azure Active Directory Application Secret
+AZURE_SUBSCRIPTION_ID: with your Azure Subscription Id
+"""
+
 import os
 
 from haikunator import Haikunator
@@ -11,13 +21,6 @@ GROUP_NAME = 'azure-sample-group'
 SERVER_FARM_NAME = 'sample-server-farm'
 SITE_NAME = Haikunator().haikunate()
 
-# This script expects that the following environment vars are set:
-#
-# AZURE_TENANT_ID: with your Azure Active Directory tenant id or domain
-# AZURE_CLIENT_ID: with your Azure Active Directory Application Client ID
-# AZURE_CLIENT_SECRET: with your Azure Active Directory Application Secret
-# AZURE_SUBSCRIPTION_ID: with your Azure Subscription Id
-#
 def run_example():
     """Web Site management example."""
     #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-azure-mgmt-resource==1.0.0rc3
+azure-mgmt-resource~=1.0.0rc0
 azure-mgmt-web==0.32.0
 haikunator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-azure-mgmt-resource~=1.0.0rc0
+azure-mgmt-resource~=1.0.0rc3
 azure-mgmt-web==0.32.0
 haikunator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-azure-mgmt-resource==0.30.0rc5
-azure-mgmt-web==0.30.0rc5
+azure-mgmt-resource==1.0.0rc3
+azure-mgmt-web==0.32.0
 haikunator


### PR DESCRIPTION
This change brings the code up to date with `azure-mgmt-web` version 0.32.0 and also updates the README to use the terminology in that new version: in particular, the term "server farm" seems to have been mostly abandoned in favor of "app service plan."

As well, `azure-mgmt-resource` has been brought up to a forward-compatible requirement of 1.0.0rc3 or later. This didn't require any code changes.

There are also some miscellaneous PEP8-related and stylistic changes: notably, a large comment has become a module-level docstring, and all top-level definitions now have 2 spaces between them instead of 1.